### PR TITLE
Setting to control the persistence of outputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "kusto",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,16 @@
     ],
     "main": "./out/extension/index.js",
     "contributes": {
+        "configuration": {
+            "type": "object",
+            "properties": {
+                "kusto.persistOutputs": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to persist the outputs of the notebook to the Kusto notebook file."
+                }
+            }
+        },
         "commands": [
             {
                 "command": "kusto.createNotebook",

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -1,0 +1,13 @@
+import * as vscode from 'vscode';
+
+export function registerConfigurationListener(context: vscode.ExtensionContext) {
+    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async e => {
+        if (e.affectsConfiguration('kusto.persistOutputs')) {
+            const userAction = await vscode.window.showInformationMessage('A setting has changed that requires a window reload to take effect.', 'Reload Window')
+
+            if (userAction === 'Reload Window') {
+                await vscode.commands.executeCommand('workbench.action.reloadWindow');
+            }
+        }
+    }));
+}

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -8,6 +8,7 @@ import { ClusterTreeView } from './activityBar/clusterView';
 import { registerNotebookConnection } from './kernel/notebookConnection';
 import { initialize } from './languageServer';
 import { monitorJupyterCells } from './languageServer/jupyterNotebook';
+import { registerConfigurationListener } from './configuration';
 
 let client: LanguageClient;
 
@@ -20,6 +21,7 @@ export function activate(context: ExtensionContext) {
     // DiagnosticProvider.register();
     ClusterTreeView.register();
     registerNotebookConnection();
+    registerConfigurationListener(context);
     initialize(context);
     monitorJupyterCells();
 }


### PR DESCRIPTION
This PR adds a setting `kusto.persistOutputs` to control if outputs should be saved to disk or not:

* `kusto.persistOutputs` is default to `false`, and when users execute a cell, the document will not become dirty. Both outputs and `statusMessage` metadata are transient.
* When `Kusto.persistOutputs` is set to `true`, outputs will mark the document as dirty and will be saved to disk.
* When the setting is modified, a notification pops up to ask users to reload the window (as now we can't update the transient options of content provider)

https://user-images.githubusercontent.com/876920/113469911-210ac280-9406-11eb-8cb9-63060ed3e87d.mov

