### PR TITLE
Exception thrown when auth expires is undefined

### DIFF
--- a/src/extension/kernel/kernel.ts
+++ b/src/extension/kernel/kernel.ts
@@ -90,11 +90,11 @@ export class Kernel implements NotebookKernel {
             }
             task.appendOutput(new NotebookCellOutput(outputItems));
         } catch (ex) {
-            const error: Error = ex;
+            const error: Error | undefined = ex;
             const data = {
-                ename: ex.message || 'Failed to execute query',
-                evalue: ex.evalue || ex['@type'] || '',
-                traceback: [error.stack || format(ex)]
+                ename: error?.name || 'Failed to execute query',
+                evalue: error?.message || '',
+                traceback: [error?.stack || format(ex)]
             };
 
             task.appendOutput(


### PR DESCRIPTION
For https://github.com/DonJayamanne/vscode-kusto/issues/24

The root cause of this is that the azure-kusto-data library is somehow throwing exceptions where the error is undefined. The code did not previously account for this, so accessing the message property incurred a TypeError that prevented the error message on the notebook output from being correctly set. The workaround here is to add more type safety when accessing the error object's message and name.

With this change, the timeout case now gets an error message like this: 
![image](https://user-images.githubusercontent.com/30305945/113825735-32213f80-9736-11eb-9f1e-90f112b04cc8.png)
 